### PR TITLE
Rbenv gem

### DIFF
--- a/lib/terraform/dsl.rb
+++ b/lib/terraform/dsl.rb
@@ -85,6 +85,21 @@ module Terraform
       end
     end
 
+    def rbenv_gem_installed?(gem, ruby_version = nil)
+      rbenv_root = ENV["RBENV_ROOT"] || "#{ENV["HOME"]}/.rbenv"
+      prefix = "env RBENV_VERSION=#{ruby_version} #{rbenv_root}/shims/" unless ruby_version.nil?
+      `#{prefix}gem list '#{gem}'`.include?(gem)
+    end
+
+    def ensure_rbenv_gem(gem, ruby_version = nil)
+      rbenv_root = ENV["RBENV_ROOT"] || "#{ENV["HOME"]}/.rbenv"
+      prefix = "env RBENV_VERSION=#{ruby_version} #{rbenv_root}/shims/" unless ruby_version.nil?
+      dep "gem: #{gem}" do
+        met? { rbenv_gem_installed?(gem) }
+        meet { shell "#{prefix}gem install #{gem} --no-ri --no-rdoc" }
+      end
+    end
+
     # Ensures the file at dest_path is exactly the same as the one in source_path.
     # Invokes the given block if the file is changed. Use this block to restart a service, for instance.
     def ensure_file(source_path, dest_path, &on_change)


### PR DESCRIPTION
Added a new method `ensure_rbenv_gem()` to allow the user to specify that a gem be installed under a specific version of Ruby.
