### PR TITLE
Upgrade terraform version to 0.0.9

### DIFF
--- a/lib/terraform/version.rb
+++ b/lib/terraform/version.rb
@@ -1,3 +1,3 @@
 module Terraform
-  VERSION = "0.0.6"
+  VERSION = "0.0.9"
 end


### PR DESCRIPTION
I burned through previous versions on our local gem server so I need to jump to 0.0.9.
